### PR TITLE
Update template_AwsS3.JSON

### DIFF
--- a/Solutions/Amazon Web Services/Data Connectors/template_AwsS3.JSON
+++ b/Solutions/Amazon Web Services/Data Connectors/template_AwsS3.JSON
@@ -2,7 +2,7 @@
     "id": "AwsS3",
     "title": "Amazon Web Services S3",
     "publisher": "Amazon",
-    "descriptionMarkdown": "This connector allows you to ingest AWS service logs, collected in AWS S3 buckets, to Microsoft Sentinel. The currently supported data types are: \n* AWS CloudTrail\n* VPC Flow Logs\n* AWS GuardDuty",
+    "descriptionMarkdown": "This connector allows you to ingest AWS service logs, collected in AWS S3 buckets, to Microsoft Sentinel. The AWS S3 connector is presently only supported for the commercial cloud. The currently supported data types are: \n* AWS CloudTrail\n* VPC Flow Logs\n* AWS GuardDuty",
     "logo": "Aws.svg",
     "graphQueries": [
         {


### PR DESCRIPTION
Add that The AWS S3 connector is presently only supported for the commercial cloud.

   Required items, please complete
   
   Change(s):
   Add that The AWS S3 connector is presently only supported for the commercial cloud.   

   Reason for Change(s):
   The connector is displaying the government environment, but it is not supported in the government domain. Additional 
   documentation has been added to clarify this.

   Version Updated: **No**
   - Required only for Detections/Analytic Rule templates
   - See guidance below

   Testing Completed:
   - See guidance below

